### PR TITLE
Scheduler init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Vendoring support
+vendor
+
+# binaries
+daemon-ecs-scheduler
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # daemon-ecs-scheduler
 A ECS scheduler that places daemons on every node in ECS cluster
+
+## Quick start
+
+`glide install`
+
+`go build`
+
+`daemon-ecs-scheduler --cluster weave-ecs-demo-cluster --tasks cadvisor:2`
+
+## Feature
+
+* Support the automatic registeration of tasks.
+

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,66 @@
+hash: 71818d75a99922343fc73d174b055a9d9d8164c5d502459d1d144738864e81d1
+updated: 2016-11-21T12:12:17.285957413+08:00
+imports:
+- name: github.com/aws/aws-sdk-go
+  version: 898c81ba64b9a467379d35e3fabad133beae0ee4
+  subpackages:
+  - aws
+  - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/request
+  - aws/session
+  - aws/signer/v4
+  - private/endpoints
+  - private/protocol
+  - private/protocol/json/jsonutil
+  - private/protocol/jsonrpc
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/xml/xmlutil
+  - private/waiter
+  - service/ecs
+  - service/ecs/ecsiface
+  - service/sts
+- name: github.com/go-ini/ini
+  version: 6e4869b434bd001f6983749881c7ead3545887d8
+- name: github.com/go-stack/stack
+  version: 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82
+- name: github.com/inconshreveable/log15
+  version: 46a701a619de90c65a78c04d1a58bf02585e9701
+  subpackages:
+  - term
+- name: github.com/jinzhu/gorm
+  version: 066abcef408f2522f0a89952e44ab17eac176ed0
+- name: github.com/jinzhu/inflection
+  version: 74387dc39a75e970e7a3ae6a3386b5bd2e5c5cff
+- name: github.com/jmespath/go-jmespath
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+- name: github.com/mattn/go-colorable
+  version: d228849504861217f796da67fae4f6e347643f15
+- name: github.com/mattn/go-isatty
+  version: 66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8
+- name: github.com/mattn/go-sqlite3
+  version: fba66eb11643069e747022997e9be3b502b2c6fb
+- name: github.com/urfave/cli
+  version: a8fc36b690712e61212d8cb9450eabf2be359fca
+- name: github.com/Wen777/ecs_state
+  version: c6b3d7fd30ef3716ca1ac7cf8e40d5cce09ee2cb
+- name: golang.org/x/net
+  version: 4971afdc2f162e82d185353533d3cf16188a9f4e
+  subpackages:
+  - context
+- name: golang.org/x/sys
+  version: b699b7032584f0953262cb2788a0ca19bb494703
+  subpackages:
+  - unix
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,14 @@
+package: github.com/hyperpilot/daemon-ecs-scheduler
+import:
+- package: github.com/aws/aws-sdk-go
+  subpackages:
+  - aws
+  - aws/awserr
+  - service/ecs
+- package: github.com/jinzhu/gorm
+- package: github.com/mattn/go-sqlite3
+- package: github.com/inconshreveable/log15
+- package: github.com/mattn/go-colorable
+- package: github.com/Wen777/ecs_state
+- package: github.com/urfave/cli
+  version: ~1.19.0

--- a/main.go
+++ b/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecs"
+
+	ecs_state "github.com/Wen777/ecs_state"
+	cli "github.com/urfave/cli"
+)
+
+// StartTask on AWS ECS Cluster
+func StartTask(CLUSTER string, TASK string) error {
+
+	// List cluster info
+	sess, _ := session.NewSession(&aws.Config{Region: aws.String("us-west-1")})
+	client := ecs.New(sess)
+
+	state := ecs_state.Initialize(CLUSTER, client)
+	state.RefreshClusterState()
+	state.RefreshContainerInstanceState()
+	state.RefreshTaskState()
+	fmt.Printf("Found Cluster: %+v\n\n", len(state.FindClusterByName(CLUSTER).ContainerInstances))
+
+	// TODO Register task definitions
+	ec2Arr := state.FindClusterByName(CLUSTER).ContainerInstances
+
+	var arrOfMissing []*string
+	for _, v := range ec2Arr {
+		flag := 0
+		for _, task := range v.Tasks {
+			if strings.Contains(task.TaskDefinitionARN, TASK) {
+				flag = 1
+				break
+			}
+		}
+		if flag == 0 {
+			arrOfMissing = append(arrOfMissing, aws.String(v.ARN))
+		}
+	}
+
+	fmt.Printf("How many containers lack the specific task %+v\n\n", len(arrOfMissing))
+
+	params := &ecs.StartTaskInput{
+		ContainerInstances: arrOfMissing,
+		TaskDefinition:     aws.String(TASK),
+		Cluster:            aws.String(CLUSTER),
+		StartedBy:          aws.String("hyperpilot-pen"),
+	}
+
+	resp, err := client.StartTask(params)
+	if err != nil {
+		fmt.Println(err.Error())
+		return err
+	}
+
+	fmt.Println(resp)
+	// TODO Add logger
+	// TODO Make it running as linux daemon
+	return nil
+}
+func main() {
+
+	// Parse parameters from command line inpu
+	var CLUSTER string
+	var TaskDef []string
+	app := cli.NewApp()
+	app.Name = "hyperpen"
+	app.Usage = "A customized scheduler by hyperpilot for AWS ECS"
+
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:        "cluster",
+			Usage:       "The name of target cluster",
+			Destination: &CLUSTER,
+		},
+		cli.StringSliceFlag{
+			Name:  "task-definitions, tasks",
+			Usage: "Start which task. Format -tasks task_name -tasks another_task_name",
+		},
+	}
+	app.Action = func(c *cli.Context) error {
+		if c.String("cluster") != "" {
+			TaskDef = c.StringSlice("task-definitions")
+			err := StartTask(CLUSTER, TaskDef[0])
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	app.Run(os.Args)
+
+}


### PR DESCRIPTION
# WHAT / WHY

* Scheduler for AWS ECS.
* Support to run the given task on each host in the same cluster.
* Parse the parameters from terminal. (add github.com/urfave/cli)

# Quick start

`glide install`

`go build`

`daemon-ecs-scheduler --cluster weave-ecs-demo-cluster --tasks cadvisor:2`

cc @tnachen 

For the installation of glide.
https://github.com/Masterminds/glide

![screenshot from 2016-11-21 04-46-42](https://cloud.githubusercontent.com/assets/7497207/20470659/7a3142a8-afe5-11e6-995c-9fbd0c2c760f.png)